### PR TITLE
feat: fontSize 테마 스타일 정의

### DIFF
--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -1,16 +1,35 @@
-const colors = {
-  // TODO: write colors based on own's design system
-};
+import { extendTheme } from "@chakra-ui/react";
 
-const fontSize = {
-  title: '2.25rem',
-  subtitle: '2rem',
-  p1: '2.5rem',
-  p2: '1.75rem',
-  p3: '1.5rem',
-  p4: '1.25rem',
-  p5: '1rem',
-  p6: '0.75rem',
-};
+const theme = extendTheme({
+  colors: {
+    // TODO: write colors based on own's design system
+  },
+  fontSizes: {
+    xs: "0.75rem",
+    sm: "0.875rem",
+    md: "1rem",
+    lg: "1.125rem",
+    xl: "1.25rem",
+    "2xl": "1.5rem",
+    "3xl": "1.875rem",
+    "4xl": "2.25rem",
+    "5xl": "3rem",
+    "6xl": "3.75rem",
+    "7xl": "4.5rem",
+    "8xl": "6rem",
+    "9xl": "8rem",
+  },
+  fontWeights: {
+    hairline: 100,
+    thin: 200,
+    light: 300,
+    normal: 400,
+    medium: 500,
+    semibold: 600,
+    bold: 700,
+    extrabold: 800,
+    black: 900,
+  },
+});
 
-export default { colors, fontSize };
+export default { theme };

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -3,7 +3,14 @@ const colors = {
 };
 
 const fontSize = {
-  // TODO: write down font size based on own's design system
+  title: '2.25rem',
+  subtitle: '2rem',
+  p1: '2.5rem',
+  p2: '1.75rem',
+  p3: '1.5rem',
+  p4: '1.25rem',
+  p5: '1rem',
+  p6: '0.75rem',
 };
 
 export default { colors, fontSize };


### PR DESCRIPTION
피그마 디자인을 기준으로 사이즈를 정의했습니다.
- title: 페이지 제목 ex) 기자재 구매
- subtitle: 페이지 세부 설명 ex) 카테고리
- p(1~6) : 유동적인 텍스트 사이즈

다른 의견 있으면 코멘트 주세요!