### PR TITLE
style: 메인페이지 UI 변경

### DIFF
--- a/src/components/Auction/AuctionItem.jsx
+++ b/src/components/Auction/AuctionItem.jsx
@@ -52,6 +52,9 @@ const ImageField = styled.img`
   background-color: #cacaca;
   border: 0.01rem solid #aaa;
   object-fit: cover;
+  &:hover {
+    opacity: 0.8;
+  }
 `;
 
 const TextField = styled.div`

--- a/src/components/Auction/AuctionPurchase.tsx
+++ b/src/components/Auction/AuctionPurchase.tsx
@@ -38,7 +38,7 @@ export const AuctionPurchase = () => {
         <Text fontSize="xx-large" fontWeight="600" mr="2rem">
           기자재 거래
         </Text>
-        <Text fontSize="larger">업종 : {auction.itemType}</Text>
+        <Text fontSize="larger">상품 카테고리 : {auction.itemType}</Text>
       </Flex>
       <Divider orientation="horizontal" />
       <Flex flexDirection="column">

--- a/src/components/Main/MainFeed.jsx
+++ b/src/components/Main/MainFeed.jsx
@@ -28,7 +28,7 @@ const MainFeed = ({ selectedCategory }) => {
   return (
     <Box display="flex" justifyContent="center">
       {filteredMaterials.length > 0 ? (
-        <Grid templateColumns="repeat(4, 1fr)" gap="10">
+        <Grid templateColumns="repeat(5, 1fr)" gap="10">
           {filteredMaterials.map((material) => (
             <Card
               key={material.id}
@@ -48,7 +48,6 @@ const MainFeed = ({ selectedCategory }) => {
                     : material.productName}
                 </Text>
                 <Flex justifyContent="space-between">
-                  <Text color="gray.500">{material.itemType}</Text>
                   <Text fontWeight="bold">
                     {material.totalPrice.toLocaleString()}원
                   </Text>
@@ -70,8 +69,8 @@ export default MainFeed;
 
 const ImageWrapper = styled.div`
   position: relative;
-  height: 23rem;
-  width: 17rem;
+  height: 13rem;
+  width: 13rem;
 `;
 
 const ImageField = styled.img`
@@ -79,6 +78,9 @@ const ImageField = styled.img`
   width: 100%;
   background-color: #cacaca;
   object-fit: cover;
+  &:hover {
+    opacity: 0.8;
+  }
 `;
 
 const SoldOutText = styled.div`

--- a/src/components/Purchase/Purchase.tsx
+++ b/src/components/Purchase/Purchase.tsx
@@ -68,7 +68,7 @@ export const Purchase = () => {
         <Text fontSize="xx-large" fontWeight="600" mr="2rem">
           기자재 거래
         </Text>
-        <Text fontSize="larger">업종 : {material.itemType}</Text>
+        <Text fontSize="larger">상품 카테고리 : {material.itemType}</Text>
       </Flex>
       <Divider orientation="horizontal" />
       <Flex flexDirection="column">

--- a/src/pages/AuctionListPage.jsx
+++ b/src/pages/AuctionListPage.jsx
@@ -20,7 +20,7 @@ const AuctionListPage = () => {
 
   return (
     <PageLayout>
-      <Header showIconsAndTexts={false} />
+      <Header showIconsAndTexts={true} />
       <Flex alignItems="center" justifyContent="space-between" mb={4}>
         <AuctionTitle title="기자재 경매 목록" />
         <Button


### PR DESCRIPTION
![image](https://github.com/jnu-resellers/resellers-fe/assets/129190157/c4bb7298-0d26-49d9-be55-410513985f0a)
메인페이지에서 한 화면에 더 많은 상품이 보이도록 UI를 변경하였습니다. 이 과정에서 카테고리에 대해서 정보를 제공할 필요가 없다고 판단해 제거하였습니다.
메인페이지와 경매목록 페이지에서 이미지 호버 시 이미지 투명도를 조절해 마우스가 올라간 것을 인지 할 수 있도록 했습니다.
상세페이지에서 업종이라는 단어를 아직 사용 중인 것을 확인해서 상품 카테고리로 대체했습니다.
