### PR TITLE
feat: 기자재 상세 페이지 스타일 세부 수정

### DIFF
--- a/src/components/Auction/AuctionPurchase.tsx
+++ b/src/components/Auction/AuctionPurchase.tsx
@@ -19,7 +19,7 @@ export const AuctionPurchase = () => {
 
   return (
     <Box w="100%" p={{ base: 2, sm: 4, md: 6 }}>
-      <Flex justifyContent="start" alignItems="center" flexWrap="wrap">
+      <Flex justifyContent="start" alignItems="center" flexWrap="wrap" gap={4}>
         <Text
           fontSize={{ base: 'xl', sm: '2xl', md: '3xl', lg: '4xl' }}
           fontWeight="600"

--- a/src/components/Purchase/Purchase.tsx
+++ b/src/components/Purchase/Purchase.tsx
@@ -64,7 +64,7 @@ export const Purchase = () => {
 
   return (
     <Box w="100%" p={{ base: 2, sm: 4, md: 6 }}>
-      <Flex justifyContent="start" alignItems="center" flexWrap="wrap">
+      <Flex justifyContent="start" alignItems="center" flexWrap="wrap" gap={4}>
         <Text
           fontSize={{ base: 'xl', sm: '2xl', md: '3xl', lg: '4xl' }}
           fontWeight="600"

--- a/src/components/TransactionInformation/ProductInformation.jsx
+++ b/src/components/TransactionInformation/ProductInformation.jsx
@@ -24,6 +24,7 @@ const ProductInformation = ({ productInfo, totalPrice }) => {
       <TableContainer
         mt="4"
         ml={{ base: '4', md: '0' }}
+        display={{ base: 'none', md: 'block' }}
         borderRadius="lg"
         border="1px"
         borderColor="gray.200"
@@ -55,6 +56,44 @@ const ProductInformation = ({ productInfo, totalPrice }) => {
               </Td>
               <Td whiteSpace="normal" fontSize={{ base: '10', md: '14' }}>
                 {productInfo.description}
+              </Td>
+              <Td whiteSpace="normal" fontSize={{ base: '10', md: '14' }}>
+                {productInfo.defect}
+              </Td>
+            </Tr>
+          </Tbody>
+        </Table>
+      </TableContainer>
+      <TableContainer
+        mt="4"
+        display={{ base: 'block', md: 'none' }}
+        borderRadius="lg"
+        border="1px"
+        borderColor="gray.200"
+        maxW="100%"
+        overflowX="auto"
+      >
+        <Table variant="simple">
+          <Tbody>
+            <Tr>
+              <Td fontSize={{ base: '12', md: '16' }} fontWeight="900">
+                제품명
+              </Td>
+              <Td whiteSpace="normal" fontSize={{ base: '10', md: '14' }}>
+                {productInfo.productName}
+              </Td>
+            </Tr>
+            <Tr>
+              <Td fontSize={{ base: '12', md: '16' }} fontWeight="900">
+                설명
+              </Td>
+              <Td whiteSpace="normal" fontSize={{ base: '10', md: '14' }}>
+                {productInfo.description}
+              </Td>
+            </Tr>
+            <Tr>
+              <Td fontSize={{ base: '12', md: '16' }} fontWeight="900">
+                결함
               </Td>
               <Td whiteSpace="normal" fontSize={{ base: '10', md: '14' }}>
                 {productInfo.defect}


### PR DESCRIPTION
![image](https://github.com/jnu-resellers/resellers-fe/assets/77495584/8a68899d-9b79-4afc-9a40-87feff674ec5)
- 카테고리에 gap 추가
- 다른 여백과 가운데 정렬 사항들은 헤더가 해결되니 잘 적용됩니다!

close - #100 