### PR TITLE
fix: 기자재 상세 구매페이지 스타일 변경

### DIFF
--- a/src/components/Purchase/Purchase.tsx
+++ b/src/components/Purchase/Purchase.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Text, Divider, theme } from '@chakra-ui/react';
+import { Box, Flex, Text, Divider } from '@chakra-ui/react';
 import { PurchaseDetails } from './PurchaseDetails';
 import { getMaterial } from 'src/apis/materials';
 import { useQuery, useMutation } from '@tanstack/react-query';
@@ -84,18 +84,9 @@ export const Purchase = () => {
             writer={material.writer}
             product={material.product}
             contact={material.contact}
+            onSubmitOrder={onSubmitOrder}
+            isSold={material.product.isSold || false}
           />
-          <Button
-            px={{ base: 4, lg: 28 }}
-            py={{ base: 2, lg: 6 }}
-            color="white"
-            bgColor={theme.colors.orange[300]}
-            alignSelf="flex-end"
-            isDisabled={material.product.isSold}
-            onClick={onSubmitOrder}
-          >
-            주문 신청
-          </Button>
         </Box>
       </Flex>
     </Box>

--- a/src/components/Purchase/PurchaseDetails.tsx
+++ b/src/components/Purchase/PurchaseDetails.tsx
@@ -1,8 +1,23 @@
-import { Flex, Text, Box, Divider } from '@chakra-ui/react';
+import { Flex, Text, Box, Divider, Button, theme } from '@chakra-ui/react';
 import { DescriptionBox } from './DescriptionBox';
-import { PurchaseProps } from './Purchase';
 import { PurchaseImages } from './PurchaseImages';
 import { PriceCheck } from './PriceCheck';
+
+interface PurchaseDetailsProps {
+  writer: string;
+  product: {
+    productId: number;
+    productName: string;
+    price: number;
+    description: string;
+    defect: string;
+    fileNames: string[];
+  };
+  contact: string;
+  itemType: string;
+  isSold: boolean;
+  onSubmitOrder: () => void;
+}
 
 const priceFormatter = (price: number) => {
   return price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
@@ -13,7 +28,9 @@ export const PurchaseDetails = ({
   product: { productId, productName, price, description, defect, fileNames },
   contact,
   itemType,
-}: PurchaseProps) => {
+  isSold,
+  onSubmitOrder,
+}: PurchaseDetailsProps) => {
   return (
     <Flex
       flexDirection="column"
@@ -32,14 +49,28 @@ export const PurchaseDetails = ({
       </Text>
       <Divider orientation="horizontal" mb="1rem" />
       <Box key={productId}>
-        <Text fontSize={{ base: '2xl', sm: '3xl', md: '4xl' }}>
-          {priceFormatter(price)}원
-        </Text>
+        <Flex justifyContent="space-between">
+          <Text fontSize={{ base: '2xl', sm: '3xl', md: '4xl' }}>
+            {priceFormatter(price)}원
+          </Text>
+          <Button
+            float="right"
+            px={{ base: 4, lg: 28 }}
+            py={{ base: 2, lg: 6 }}
+            color="white"
+            bgColor={theme.colors.orange[300]}
+            alignSelf="flex-end"
+            isDisabled={isSold}
+            onClick={onSubmitOrder}
+          >
+            주문 신청
+          </Button>
+        </Flex>
         <PurchaseImages fileNames={fileNames} />
         <Text
           fontSize={{ base: 'xl', sm: '2xl', md: '3xl' }}
           fontWeight="600"
-          marginBottom="2rem"
+          m="2rem 0 2rem 0"
         >
           설명
         </Text>

--- a/src/components/Purchase/PurchaseImages.tsx
+++ b/src/components/Purchase/PurchaseImages.tsx
@@ -25,9 +25,9 @@ export const PurchaseImages = ({ fileNames }: PurchaseImagesProps) => {
     <Flex
       flexDirection="row"
       w="100%"
-      m={{ base: 4, lg: '2.25rem' }}
       maxW={{ base: '20rem', lg: '32rem' }}
       justify="center"
+      mt={{ base: 4, sm: 6, lg: 8 }}
     >
       <Slider {...settings}>
         {fileNames.map((fileName: string) => (


### PR DESCRIPTION
<img width="965" alt="스크린샷 2024-06-10 오전 11 55 44" src="https://github.com/jnu-resellers/resellers-fe/assets/77495584/c70651f8-6f29-4f3b-9fab-698d3815c27f">
<img width="468" alt="스크린샷 2024-06-10 오전 11 55 33" src="https://github.com/jnu-resellers/resellers-fe/assets/77495584/62b266b9-2743-407f-b354-7922f4a5767b">

- 주문 신청 버튼 상단으로 이동
- 이미지와 정보가 정렬되어 보이게 변경

close #117 